### PR TITLE
pyxenon 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Currently, Xenon library version 1.1.0 is placed in the `libs` directory with it
 
 Except for initialization and finalization, the API follows the [Xenon 1.1.0 Java API](http://nlesc.github.io/Xenon/versions/1.1.0/javadoc/). First `xenon.init()` must be called to set up the Java Virtual Machine and its classpath. Then `x = xenon.Xenon()` creates a new Xenon instance. Either use with-resources syntax, as shown the following example, or call `x.close()` to end Xenon. If neither is done, the object destructor will try to finalize Xenon. However, Python does not guarantee that this destructor is called, which may cause a Java process running after python has finished execution.
 
+See [JPype documentation](https://jpype.readthedocs.io) for how to use Java classes in Python.
+
 ```python
 import xenon
 import os

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ config_files = list(glob(os.path.join('libs', '*.xml')))
 data_files = [('libs', jar_files + config_files)]
 
 setup(name='pyxenon',
-      version='0.1.0',
+      version='0.2.0',
       description='Python wrapper for the Xenon API.',
       author='Joris Borgdorff',
       author_email='j.borgdorff@esciencecenter.nl',
@@ -61,6 +61,6 @@ setup(name='pyxenon',
         'Topic :: System :: Distributed Computing',
       ],
       data_files=data_files,
-      install_requires=['JPype1', 'future'],
-      tests_require=['nose', 'pyflakes', 'pep8', 'coverage']
+      install_requires=['JPype1'],
+      tests_require=['nose', 'pyflakes', 'pep8', 'coverage'],
       )


### PR DESCRIPTION
Changes since version 0.1.0:

* Because the pyjnius Java interface was very hard to install using pip, including for people just using the pyxenon library, we switched to JPype as a Java interface. The API has been kept the same, but part of this change may be exposed to users in terms of error messages and slight changes to calling functions with multiple signatures (e.g. which System.out.println function is called depends on what object type is passed, and you need a JPype function now to make that distinction).
* we added some conversion functions to deal with Java streams and dict<->HashMap conversion
* added a license and notice file
* Using Xenon 1.1.0 release instead of the snapshot release.